### PR TITLE
Set cookies differently

### DIFF
--- a/ep_signatureauth.js
+++ b/ep_signatureauth.js
@@ -95,14 +95,14 @@ exports.authorize = function(hook_name, context, cb) {
         const url_payload = url.split("&signature=")[0];
         const signature = context.req.query.signature;
         cookies.set(
-          simpleUrl, `{ "signature": "${signature}", "payload": "${url_payload}" }`, { overwrite: true, maxAge: 100000000 }
+          "etherpad_security", `{ "signature": "${signature}", "payload": "${url_payload}" }`, { overwrite: true, maxAge: 100000000 }
         );
         return context.res.redirect(simpleUrl);
       } else {
         return cb([false]);
       }
     } else {
-      const cookie = cookies.get(url);
+      const cookie = cookies.get("etherpad_security");
       if (cookie) {
         const cookieValid = verifyCookie(cookie);
         if (cookieValid) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_signatureauth",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Enable secure sign-in and signature verification from Canvas LMS with Etherpad collaborations tool.",
   "author": "emdurr <ericdurr@atomicjolt.com> (Eric Durr)",
   "contributors": [],


### PR DESCRIPTION
Use a generic name instead of the path from the request.
This fixes an issue where the cookie might get set to `/p/i123` but in subsequent requests the path might be `/p/i123/timeslider` and will make the cookie lookup fail.